### PR TITLE
Can disable send button

### DIFF
--- a/src/Send.js
+++ b/src/Send.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View, ViewPropTypes } from 'react-native';
 import Color from './Color';
 
-export default function Send({ text, containerStyle, onSend, children, textStyle, label, alwaysShowSend }) {
+export default function Send({ text, containerStyle, onSend, children, textStyle, label, alwaysShowSend, disabled }) {
   if (alwaysShowSend || text.trim().length > 0) {
     return (
       <TouchableOpacity
@@ -17,6 +17,7 @@ export default function Send({ text, containerStyle, onSend, children, textStyle
           onSend({ text: text.trim() }, true);
         }}
         accessibilityTraits="button"
+        disabled={disabled}
       >
         <View>{children || <Text style={[styles.text, textStyle]}>{label}</Text>}</View>
       </TouchableOpacity>
@@ -49,6 +50,7 @@ Send.defaultProps = {
   textStyle: {},
   children: null,
   alwaysShowSend: false,
+  disabled: false,
 };
 
 Send.propTypes = {
@@ -59,4 +61,5 @@ Send.propTypes = {
   textStyle: Text.propTypes.style,
   children: PropTypes.element,
   alwaysShowSend: PropTypes.bool,
+  disabled: PropTypes.bool,
 };


### PR DESCRIPTION
In `Send` component I've added a `disabled` prop so the button can be disabled in `renderSend`:

``` js
const renderSend = ({ text, ...props }) => (
  <Send
    {...props}
    text={text}
    disabled={text.trim() === ''}
  >
    <Icon
      android="md-send"
      ios="ios-send"
      fontSize={100}
      color="#FFFFFF"
    />
  </Send>
);
```