### PR TITLE
fix: message container height does not change when min input tool bar height prop changes

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -102,6 +102,13 @@ class GiftedChat extends React.Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.minInputToolbarHeight !== this.props.minInputToolbarHeight) {
+      const messagesContainerHeight = this.prepareMessagesContainerHeight(this.getBasicMessagesContainerHeight());
+      this.setState({ messagesContainerHeight }); // eslint-disable-line react/no-did-update-set-state
+    }
+  }
+
   componentWillMount() {
     const { messages, text } = this.props;
     this.setIsMounted(true);


### PR DESCRIPTION
When updating `minInputToolbarHeight` prop the message container height does not change. This fixes the problem.