### PR TITLE
fix yeppik keyboard covers text

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -129,6 +129,7 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   /* infinite scroll up when reach the top of messages container, automatically call onLoadEarlier function if exist */
   infiniteScroll?: boolean
   timeTextStyle?: LeftRightStyle<TextStyle>
+  updateInitiallyContainerHeight?: boolean
   /* Custom action sheet */
   actionSheet?(): {
     showActionSheetWithOptions: (
@@ -454,6 +455,14 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
 
     if (text !== prevProps.text) {
       this.setTextFromProp(text)
+    }
+
+    if (this.props.updateInitiallyContainerHeight) {
+      this.setState({
+        messagesContainerHeight: this.getBasicMessagesContainerHeight(
+          this.state.composerHeight,
+        ),
+      })
     }
   }
 

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -129,7 +129,7 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   /* infinite scroll up when reach the top of messages container, automatically call onLoadEarlier function if exist */
   infiniteScroll?: boolean
   timeTextStyle?: LeftRightStyle<TextStyle>
-  updateInitiallyContainerHeight?: boolean
+  updateContainerHeight?: boolean
   /* Custom action sheet */
   actionSheet?(): {
     showActionSheetWithOptions: (
@@ -457,7 +457,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
       this.setTextFromProp(text)
     }
 
-    if (this.props.updateInitiallyContainerHeight) {
+    if (this.props.updateContainerHeight) {
       this.setState({
         messagesContainerHeight: this.getBasicMessagesContainerHeight(
           this.state.composerHeight,

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -129,7 +129,6 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   /* infinite scroll up when reach the top of messages container, automatically call onLoadEarlier function if exist */
   infiniteScroll?: boolean
   timeTextStyle?: LeftRightStyle<TextStyle>
-  updateContainerHeight?: boolean
   /* Custom action sheet */
   actionSheet?(): {
     showActionSheetWithOptions: (
@@ -457,7 +456,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
       this.setTextFromProp(text)
     }
 
-    if (this.props.updateContainerHeight) {
+    if (this.props.minInputToolbarHeight > prevProps.minInputToolbarHeight) {
       this.setState({
         messagesContainerHeight: this.getBasicMessagesContainerHeight(
           this.state.composerHeight,


### PR DESCRIPTION
`updateInitiallyContainerHeight` is an optional boolean to provide and whenever messages container height is needed to be updated outside the scope of keyboard events (now container height is updated only when native keyboard hides or shows). If set to **true** the message container height is changed inside componentDidUpdate otherwise **false** value wont affect anything.