### PR TITLE
fix chat height for large inputs

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -456,7 +456,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
       this.setTextFromProp(text)
     }
 
-    if (this.props.minInputToolbarHeight > prevProps.minInputToolbarHeight) {
+    if (this.props.minInputToolbarHeight != prevProps.minInputToolbarHeight) {
       this.setState({
         messagesContainerHeight: this.getBasicMessagesContainerHeight(
           this.state.composerHeight,


### PR DESCRIPTION
**Issue**: When typing large content (more than one row) in rich text editor inside conversation and then clearing/sending the message, composer's height is reset but not messages container's which seems to get stuck and not resetting (more obvious when scrolling).