### PR TITLE
Remove extra render related to typingDisabled

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -629,7 +629,6 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     this.handleTextInputFocusWhenKeyboardShow()
 
     if (this.props.isKeyboardInternallyHandled) {
-      this.setIsTypingDisabled(true)
       this.setKeyboardHeight(
         e.endCoordinates ? e.endCoordinates.height : e.end.height,
       )
@@ -637,6 +636,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
       const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard()
       this.setState({
         messagesContainerHeight: newMessagesContainerHeight,
+        typingDisabled: false,
       })
     }
   }
@@ -645,12 +645,12 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     this.handleTextInputFocusWhenKeyboardHide()
 
     if (this.props.isKeyboardInternallyHandled) {
-      this.setIsTypingDisabled(true)
       this.setKeyboardHeight(0)
       this.setBottomOffset(0)
       const newMessagesContainerHeight = this.getBasicMessagesContainerHeight()
       this.setState({
         messagesContainerHeight: newMessagesContainerHeight,
+        typingDisabled: false,
       })
     }
   }
@@ -659,14 +659,12 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     if (Platform.OS === 'android') {
       this.onKeyboardWillShow(e)
     }
-    this.setIsTypingDisabled(false)
   }
 
   onKeyboardDidHide = (e: any) => {
     if (Platform.OS === 'android') {
       this.onKeyboardWillHide(e)
     }
-    this.setIsTypingDisabled(false)
   }
 
   scrollToBottom(animated = true) {


### PR DESCRIPTION
Updating `typingDisabled` before keyboard is shown/hidden causes an extra rendering. Considering that keyboard showing or hiding is a pretty quick process, there is no need for disabling typing at that specific moment (right before keyboard is shown/hidden) and enabling again once show/hide process is completed.